### PR TITLE
Chore/sl 4/application

### DIFF
--- a/src/main/java/com/startlion/startlionserver/config/SwaggerConfig.java
+++ b/src/main/java/com/startlion/startlionserver/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
 
     @Bean
     public GroupedOpenApi chatOpenApi() {
-        String[] paths = {"/**"}; // 기본 경로
+        String[] paths = {"/application/**", "/login/**", "/member/**"}; // 기본 경로
 
         return GroupedOpenApi.builder()
                 .group("START LION API v1")

--- a/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
@@ -3,6 +3,8 @@ package com.startlion.startlionserver.controller;
 import com.startlion.startlionserver.dto.request.application.*;
 import com.startlion.startlionserver.dto.response.application.ApplicationPage1GetResponse;
 import com.startlion.startlionserver.service.ApplicationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -18,12 +20,14 @@ public class ApplicationController {
     private final ApplicationService applicationService;
 
     // 저장된 지원서 없을 시, 지원서 1페이지 정보(질문) 가져오기
+    @Operation(summary = "저장된 지원서 없을 시, 지원서 1페이지 정보(질문) 가져오기")
     @GetMapping
     public ResponseEntity<ApplicationPage1GetResponse> getApplicationPersonalInformation(){
         return ResponseEntity.ok(applicationService.getApplicationPersonalInformation());
     }
 
     // 저장된 지원서 있을 시, 지원서 정보 가져오기
+    @Operation(summary = "저장된 지원서 있을 시, 지원서 정보 가져오기")
     @GetMapping("/{applicationId}")
     public ResponseEntity<?> getApplication(@PathVariable Long applicationId, @RequestParam int page)  {
         return ResponseEntity.ok(applicationService.getById(applicationId, page));
@@ -31,29 +35,33 @@ public class ApplicationController {
 
     // 지원서 저장하기의 경우 받아야 하는 Body 정보가 다르기 때문에, 4개의 API로 나누었습니다.
     // 지원서 저장하기 1페이지
+    @Operation(summary = "지원서 저장하기 1페이지")
     @PutMapping("/{applicationId}/page1")
-    public ResponseEntity<String> updateApplicationPage1(@PathVariable Long applicationId, @RequestBody ApplicationPage1PutRequest request, @RequestParam Long generationId){
+    public ResponseEntity<String> updateApplicationPage1(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage1PutRequest request, @RequestParam Long generationId){
         URI uri = URI.create("/application/" + applicationService.updateApplicationPage1(applicationId, request, generationId));
         return ResponseEntity.created(uri).body("지원서 1페이지 저장 완료");
     }
 
     // 지원서 저장하기 2페이지
+    @Operation(summary = "지원서 저장하기 2페이지")
     @PutMapping("/{applicationId}/page2")
-    public ResponseEntity<String> updateApplicationPage2(@PathVariable Long applicationId, @RequestBody ApplicationPage2PutRequest request){
+    public ResponseEntity<String> updateApplicationPage2(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage2PutRequest request){
         URI uri = URI.create("/application/" + applicationService.updateApplicationPage2(applicationId, request));
         return ResponseEntity.created(uri).body("지원서 2페이지 저장 완료");
     }
 
     // 지원서 저장하기 3페이지
+    @Operation(summary = "지원서 저장하기 3페이지")
     @PutMapping("/{applicationId}/page3")
-    public ResponseEntity<String> updateApplicationPage3(@PathVariable Long applicationId, @RequestBody ApplicationPage3PutRequest request){
+    public ResponseEntity<String> updateApplicationPage3(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage3PutRequest request){
         URI uri = URI.create("/application/" + applicationService.updateApplicationPage3(applicationId, request));
         return ResponseEntity.created(uri).body("지원서 3페이지 저장 완료");
     }
 
     // 지원서 저장하기 4페이지 -> 제출
+    @Operation(summary = "지원서 저장하기 4페이지 -> 제출")
     @PutMapping("/{applicationId}/page4")
-    public ResponseEntity<String> updateApplicationPage4(@PathVariable Long applicationId, @RequestBody ApplicationPage4PutRequest request){
+    public ResponseEntity<String> updateApplicationPage4(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage4PutRequest request){
         URI uri = URI.create("/application/" + applicationService.updateApplicationPage4(applicationId, request));
         return ResponseEntity.created(uri).body("지원서 제출 완료");
     }

--- a/src/main/java/com/startlion/startlionserver/controller/AuthApiController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/AuthApiController.java
@@ -2,6 +2,7 @@ package com.startlion.startlionserver.controller;
 
 import com.startlion.startlionserver.service.AuthService;
 import com.startlion.startlionserver.domain.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,6 +43,7 @@ public class AuthApiController {
     private String googleClientSecret;
 
     private String reqUrl;
+    @Operation(summary = "소셜 로그인")
     @GetMapping("/login")
     public ResponseEntity<?> getGoogleAuthUrl() throws Exception {
 
@@ -56,6 +58,7 @@ public class AuthApiController {
 
     }
 
+    @Operation(summary = "소셜 로그인 성공")
     @GetMapping("/login/oauth2/code/google")
     public Map<String, Object> oauthGoogleCheck(@RequestParam(value = "code") String authCode) throws Exception{
 
@@ -63,6 +66,7 @@ public class AuthApiController {
         return returnvalue;
     }
 
+    @Operation(summary = "멤버")
     @GetMapping("/member")
     public Authentication getCurrentUser(Authentication authentication) {
         return authentication;

--- a/src/main/java/com/startlion/startlionserver/domain/entity/Application.java
+++ b/src/main/java/com/startlion/startlionserver/domain/entity/Application.java
@@ -112,7 +112,7 @@ public class Application extends BaseTimeEntity {
         this.status = status;
     }
 
-    public void updateApplication(boolean isAgreed, String name, String gender, Integer studentNum, String major, String multiMajor, String semester, String phone, String email, List<PathToKnow> pathToKnows, Part part, String status, CommonQuestion generation){
+    public void updateApplication(boolean isAgreed, User user,String name, String gender, Integer studentNum, String major, String multiMajor, String semester, String phone, String email, List<PathToKnow> pathToKnows, Part part, String status, CommonQuestion generation){
         this.isAgreed = isAgreed;
         this.name = name;
         this.gender = gender;
@@ -126,6 +126,7 @@ public class Application extends BaseTimeEntity {
         this.part = part;
         this.status = status;
         this.generation = generation;
+        this.user = user;
     }
 
     public void setAnswer(Answer answer) {

--- a/src/main/java/com/startlion/startlionserver/dto/request/application/ApplicationPage1PutRequest.java
+++ b/src/main/java/com/startlion/startlionserver/dto/request/application/ApplicationPage1PutRequest.java
@@ -2,6 +2,7 @@ package com.startlion.startlionserver.dto.request.application;
 
 import com.startlion.startlionserver.domain.entity.Part;
 import com.startlion.startlionserver.domain.entity.PathToKnow;
+import com.startlion.startlionserver.domain.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -21,4 +22,5 @@ public class ApplicationPage1PutRequest {
     private String email;
     private List<PathToKnow> pathToKnows;
     private Part part;
+    private User user;
 }

--- a/src/main/java/com/startlion/startlionserver/repository/CommonQuestionRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/CommonQuestionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CommonQuestionRepository extends JpaRepository<CommonQuestion, Long> {
-    Optional<CommonQuestion> findByGeneration(Long generation);
+    Optional<CommonQuestion> findByGeneration(Long generationId);
 }

--- a/src/main/java/com/startlion/startlionserver/service/ApplicationService.java
+++ b/src/main/java/com/startlion/startlionserver/service/ApplicationService.java
@@ -78,11 +78,12 @@ public class ApplicationService {
         // applicationId가 존재하면 update, 존재하지 않으면 create
         if (optionalApplication.isPresent()) {
             application = optionalApplication.get();
-            application.updateApplication(request.getIsAgreed(), request.getName(), request.getGender(), request.getStudentNum(), request.getMajor(), request.getMultiMajor(), request.getSemester(), request.getPhone(), request.getEmail(), request.getPathToKnows(), request.getPart(), "S", commonQuestion);
+            application.updateApplication(request.getIsAgreed(), request.getUser(),request.getName(), request.getGender(), request.getStudentNum(), request.getMajor(), request.getMultiMajor(), request.getSemester(), request.getPhone(), request.getEmail(), request.getPathToKnows(), request.getPart(), "S", commonQuestion);
         } else {
             application = Application.builder()
                     .generation(commonQuestionRepository.findById(generationId)
                             .orElseThrow(() -> new IllegalArgumentException("해당 commonQuestionId를 가진 commonQuestion이 존재하지 않습니다.")))
+                    .user(request.getUser())
                     .isAgreed(request.getIsAgreed())
                     .name(request.getName())
                     .gender(request.getGender())
@@ -151,4 +152,3 @@ public class ApplicationService {
     }
 
 }
-

--- a/src/main/java/com/startlion/startlionserver/service/AuthService.java
+++ b/src/main/java/com/startlion/startlionserver/service/AuthService.java
@@ -6,12 +6,14 @@ import com.startlion.startlionserver.dto.response.GoogleLoginResponse;
 import com.startlion.startlionserver.dto.request.GoogleOAuthRequest;
 import com.startlion.startlionserver.repository.UserRepository;
 import com.startlion.startlionserver.domain.entity.User;
+import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -44,6 +46,8 @@ public class AuthService {
 
     @Autowired
     private com.startlion.startlionserver.auth.jwtTokenProvider jwtTokenProvider;
+
+    @Transactional
     public Map<String, Object> authenticateUser(String authCode) throws Exception{
 
         GoogleOAuthRequest googleOAuthRequest = GoogleOAuthRequest
@@ -78,16 +82,14 @@ public class AuthService {
         User user = userRepository.findByEmail(email);
         if (user == null) {
             User newUser = new User();
-            saveUserTokens(newUser);
             newUser.join(email,username,socialId,imageUrl);
+            saveUserTokens(newUser);
             userRepository.save(newUser);
-
             return result;
         }
         else {
             User findUser = userRepository.findByEmail(email);
             saveUserTokens(findUser);
-
             return result;
         }
 


### PR DESCRIPTION
##티켓

[SL-4]

##변경사항

- application 생성 시 userId도 넘겨서 application과 user 정보가 연결될 수 있도록 변경했습니다.
- swagger 사용 시 만든 URI에 대해서만 나타나도록 했고, swagger 접속 시 추가 정보들 입력했습니다.

<br>

##스크린샷
![image](https://github.com/cau-likelion-org/startlion-server/assets/102143229/1e937e5d-d805-4e27-9bc8-953fb40d25fc)
- userId 정보도 요청을 보낼 때 같이 넘겨서 table에 저장합니다.

![image](https://github.com/cau-likelion-org/startlion-server/assets/102143229/85165be0-5615-4575-9c2b-e80d89848777)
- 이제 application 의 user 컬럼도 채워집니다.


![image](https://github.com/cau-likelion-org/startlion-server/assets/102143229/216dc7ab-d714-44c6-9fd0-9a32391aef3a)
- 이런 식으로 swagger은 나타나게 됩니다.