### PR TITLE
[SL-5 FEAT] 인터뷰, 파트 정보 조회 API 개발

### DIFF
--- a/src/main/java/com/startlion/startlionserver/controller/InterviewController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/InterviewController.java
@@ -1,0 +1,36 @@
+package com.startlion.startlionserver.controller;
+
+
+import com.startlion.startlionserver.dto.response.interview.InterviewResponse;
+import com.startlion.startlionserver.service.InterviewService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/interviews")
+public class InterviewController {
+
+    private final InterviewService interviewService;
+
+
+    @GetMapping
+    public ResponseEntity<List<InterviewResponse>> getInterviews() {
+        val response = interviewService.getInterviews();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("{interviewId}")
+    public ResponseEntity<InterviewResponse> getInterviewById(@PathVariable Long interviewId) {
+        val response = interviewService.getInterviewById(interviewId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/controller/PartController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/PartController.java
@@ -1,0 +1,23 @@
+package com.startlion.startlionserver.controller;
+
+import com.startlion.startlionserver.dto.response.part.PartResponse;
+import com.startlion.startlionserver.service.PartService;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/parts")
+public class PartController {
+
+    private final PartService partService;
+
+    @GetMapping("{partId}")
+    public ResponseEntity<PartResponse> getPart(@PathVariable Long partId
+    ) {
+        val response = partService.getPartById(partId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/dto/response/interview/InterviewListResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/interview/InterviewListResponse.java
@@ -1,0 +1,8 @@
+package com.startlion.startlionserver.dto.response.interview;
+
+import java.util.List;
+
+public record InterviewListResponse(
+        List<InterviewResponse> interviews
+) {
+}

--- a/src/main/java/com/startlion/startlionserver/dto/response/interview/InterviewResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/interview/InterviewResponse.java
@@ -1,0 +1,37 @@
+package com.startlion.startlionserver.dto.response.interview;
+
+
+import com.startlion.startlionserver.domain.entity.Interview;
+import com.startlion.startlionserver.domain.entity.InterviewAnswer;
+import com.startlion.startlionserver.dto.response.interviewanswer.InterviewAnswerResponse;
+
+import java.util.List;
+
+public record InterviewResponse(
+        Long interviewId,
+        String title,
+        Long generation,
+        String part,
+        String major,
+        String name,
+        String oneLineContent,
+        String oneLineAnswer,
+        String imageUrl,
+        List<InterviewAnswerResponse> interviewAnswers
+) {
+
+    public static InterviewResponse of(Interview interview, List<InterviewAnswerResponse> interviewAnswers) {
+        return new InterviewResponse(
+                interview.getInterviewId(),
+                interview.getTitle(),
+                interview.getGeneration(),
+                interview.getPart(),
+                interview.getMajor(),
+                interview.getName(),
+                interview.getOneLineContent(),
+                interview.getOneLineAnswer(),
+                interview.getImageUrl(),
+                interviewAnswers
+        );
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/dto/response/interviewanswer/InterviewAnswerResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/interviewanswer/InterviewAnswerResponse.java
@@ -1,0 +1,15 @@
+package com.startlion.startlionserver.dto.response.interviewanswer;
+
+import com.startlion.startlionserver.domain.entity.InterviewAnswer;
+
+public record InterviewAnswerResponse(
+        Long interviewAnswerId,
+        String answer
+) {
+
+    public static InterviewAnswerResponse of(InterviewAnswer interviewAnswer) {
+        return new InterviewAnswerResponse(
+                interviewAnswer.getInterviewAnswerId(),
+                interviewAnswer.getAnswer());
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
@@ -1,0 +1,18 @@
+package com.startlion.startlionserver.dto.response.part;
+
+import com.startlion.startlionserver.domain.entity.Part;
+import lombok.Data;
+
+
+public record PartResponse(
+        String partContent,
+        String typeOfTalent
+) {
+
+    public static PartResponse of(Part part) {
+        return new PartResponse(
+                part.getPartContent(),
+                part.getTypeOfTalent()
+        );
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/repository/InterviewAnswerJpaRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/InterviewAnswerJpaRepository.java
@@ -1,0 +1,12 @@
+package com.startlion.startlionserver.repository;
+
+import com.startlion.startlionserver.domain.entity.Interview;
+import com.startlion.startlionserver.domain.entity.InterviewAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterviewAnswerJpaRepository extends JpaRepository<InterviewAnswer, Long> {
+
+    List<InterviewAnswer> findByInterview(Interview interview);
+}

--- a/src/main/java/com/startlion/startlionserver/repository/InterviewJpaRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/InterviewJpaRepository.java
@@ -1,0 +1,7 @@
+package com.startlion.startlionserver.repository;
+
+import com.startlion.startlionserver.domain.entity.Interview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewJpaRepository extends JpaRepository<Interview, Long> {
+}

--- a/src/main/java/com/startlion/startlionserver/repository/PartJpaRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/PartJpaRepository.java
@@ -1,0 +1,7 @@
+package com.startlion.startlionserver.repository;
+
+import com.startlion.startlionserver.domain.entity.Part;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartJpaRepository extends JpaRepository<Part, Long> {
+}

--- a/src/main/java/com/startlion/startlionserver/service/InterviewService.java
+++ b/src/main/java/com/startlion/startlionserver/service/InterviewService.java
@@ -1,0 +1,45 @@
+package com.startlion.startlionserver.service;
+
+import com.startlion.startlionserver.domain.entity.Interview;
+import com.startlion.startlionserver.domain.entity.InterviewAnswer;
+import com.startlion.startlionserver.dto.response.interview.InterviewResponse;
+import com.startlion.startlionserver.dto.response.interviewanswer.InterviewAnswerResponse;
+import com.startlion.startlionserver.repository.InterviewAnswerJpaRepository;
+import com.startlion.startlionserver.repository.InterviewJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterviewService {
+
+    private final InterviewJpaRepository interviewJpaRepository;
+    private final InterviewAnswerJpaRepository interviewAnswerJpaRepository;
+
+    public InterviewResponse getInterviewById(Long interviewId) {
+         Interview interview = interviewJpaRepository.findById(interviewId)
+                 .orElseThrow( () -> new IllegalArgumentException("해당하는 인터뷰가 없습니다."));
+
+          List<InterviewAnswerResponse> interviewAnswerResponses = interviewAnswerJpaRepository.findByInterview(interview)
+                  .stream()
+                  .map(InterviewAnswerResponse::of)
+                  .toList();
+          return InterviewResponse.of(interview, interviewAnswerResponses);
+    }
+
+    public List<InterviewResponse> getInterviews() {
+       return interviewJpaRepository.findAll()
+                .stream()
+                .map(interview ->
+                InterviewResponse.of(interview, interviewAnswerJpaRepository.findByInterview(interview)
+                .stream()
+                .map(InterviewAnswerResponse::of)
+                .toList()))
+                .toList();
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/service/PartService.java
+++ b/src/main/java/com/startlion/startlionserver/service/PartService.java
@@ -1,0 +1,23 @@
+package com.startlion.startlionserver.service;
+
+
+import com.startlion.startlionserver.domain.entity.Part;
+import com.startlion.startlionserver.dto.response.part.PartResponse;
+import com.startlion.startlionserver.repository.PartJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartService {
+
+    private final PartJpaRepository partJpaRepository;
+
+    public PartResponse getPartById(Long partId) {
+        Part part = partJpaRepository.findById(partId)
+                .orElseThrow( () -> new IllegalArgumentException("해당하는 파트가 없습니다."));
+        return PartResponse.of(part);
+    }
+}


### PR DESCRIPTION
##티켓
[SL-5]
<br>

##변경사항
- 인터뷰 조회 API 개발
- 파트 정보 조회 API 개발

<br>

##부가설명
- 파트별로 조회하는 인터뷰는 인터뷰 목록에서 클라에서 필터링 해도 좋을 것 같습니다.

<br>

##고려사항
- pull 받았을 때, Swagger관련 파일 과 오류가 존재하여 Test를 하지 못했습니다!
- 확인해주시면 좋을 것 같습니다.

<br>

##스크린샷
