### PR TITLE
[SL-4] [SL-6] security, application 관련 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+	// jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
+++ b/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
             "/health",
             "/login/oauth2/code/google",
             "/login",
+            "/application",
 
             "/swagger-resources/**",
             "/favicon.ico",

--- a/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
+++ b/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
             "/login/oauth2/code/google",
             "/login",
             "/application",
+            "/interviews/**",
+            "/parts/**",
 
             "/swagger-resources/**",
             "/favicon.ico",

--- a/src/main/java/com/startlion/startlionserver/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/startlion/startlionserver/config/jwt/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -60,6 +61,7 @@ public class JwtTokenProvider {
 
     public Long getUserFromJwt(String token) {
         Claims claims = getBody(token);
-        return Long.valueOf(claims.get("id").toString());
+        Map<String, Object> idClaim = (Map<String, Object>) claims.get("id");
+        return Long.valueOf(idClaim.get("userId").toString());
     }
 }

--- a/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
@@ -31,10 +31,6 @@ public class ApplicationController {
     }
 
     // 저장된 지원서 있을 시, 지원서 정보 가져오기
-    //TODO: 저장되어 있지 않은 페이지 조회 시 에러 해결 -> 값 없어도 조회 가능하게
-    //TODO: 리턴되는 값 수정
-    //TODO: 지원서 중복 작성시 로직 처리
-    //TODO: 인가 처리
     @Operation(summary = "저장된 지원서 있을 시, 지원서 정보 가져오기")
     @GetMapping("/{applicationId}")
     public ResponseEntity<?> getApplication(
@@ -48,8 +44,8 @@ public class ApplicationController {
     // 지원서 저장하기 1페이지
     @Operation(summary = "지원서 저장하기 1페이지")
     @PutMapping("/{applicationId}/page1")
-    public ResponseEntity<String> updateApplicationPage1(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage1PutRequest request, @RequestParam Long generationId){
-        URI uri = URI.create("/application/" + applicationService.updateApplicationPage1(applicationId, request, generationId));
+    public ResponseEntity<String> updateApplicationPage1(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage1PutRequest request, @RequestParam Long generationId, Principal principal){
+        URI uri = URI.create("/application/" + applicationService.updateApplicationPage1(applicationId, request, generationId, UserUtil.getUserId(principal)));
         return ResponseEntity.created(uri).body("지원서 1페이지 저장 완료");
     }
 

--- a/src/main/java/com/startlion/startlionserver/domain/BaseTimeEntity.java
+++ b/src/main/java/com/startlion/startlionserver/domain/BaseTimeEntity.java
@@ -1,6 +1,10 @@
 package com.startlion.startlionserver.domain;
 
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
@@ -16,8 +20,12 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
 
     @CreatedDate // 생성되는 시간에 업데이트
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt; // created_at
 
     @LastModifiedDate // 업데이트 되는 시간에 업데이트
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime updatedAt; // updated_at
 }

--- a/src/main/java/com/startlion/startlionserver/domain/entity/User.java
+++ b/src/main/java/com/startlion/startlionserver/domain/entity/User.java
@@ -32,6 +32,7 @@ public class User extends BaseTimeEntity {
 
     private String imageUrl;
 
+    @Column(length = 1024)
     private String refreshToken;
 
     private LocalDateTime expiredIn;


### PR DESCRIPTION
## 티켓
[SL-4] 
[SL-6] 

## 변경사항
- google login 과정에서 직렬화, 역직렬화 문제로 로그인이 안되는 문제 수정
- refresh token의 길이가 길어서 저장 못하는 문제 수정
- white list에 인가 없이 들어갈 수 있는 페이지 추가 (/application, /interviews/**, parts/**)
- JWT token이 userId를 가져오도록 수정 -> 기존에 id로 가져오면 invalid token이 떠서 수정했습니다.
- application 1페이지 PUT 요청의 userId 토큰으로부터 받아와서 사용할 수 있도록 수정

<br>

## 부가설명
- 여러명 리뷰어 어떻게 설정하나요,,

<br>

## 고려사항


<br>

## 스크린샷
