### PR TITLE
[SL-11 CHORE] parts return값 수정

### DIFF
--- a/src/main/java/com/startlion/startlionserver/domain/entity/Part.java
+++ b/src/main/java/com/startlion/startlionserver/domain/entity/Part.java
@@ -31,4 +31,7 @@ public class Part {
 
     @Column(length = 200)
     private String typeOfTalent;
+
+    @Column
+    private String imageUrl;
 }

--- a/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
@@ -1,18 +1,52 @@
 package com.startlion.startlionserver.dto.response.part;
 
+import com.startlion.startlionserver.domain.entity.CommonQuestion;
+import com.startlion.startlionserver.domain.entity.Curriculum;
 import com.startlion.startlionserver.domain.entity.Part;
+import com.startlion.startlionserver.domain.entity.PartQuestion;
 import lombok.Data;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 public record PartResponse(
         String partContent,
-        String typeOfTalent
+        String typeOfTalent,
+
+        String imageUrl,
+
+        List<String> partQuestions,
+        List<String> curriculumContents,
+        List<String> commonQuestions
 ) {
 
-    public static PartResponse of(Part part) {
+//    public static PartResponse of(Part part) {
+//        return new PartResponse(
+//                part.getPartContent(),
+//                part.getTypeOfTalent(),
+//                part.getImageUrl()
+//        );
+
+    public static PartResponse of(Part part, List<PartQuestion> partQuestions, List<Curriculum> curriculums, CommonQuestion commonQuestion) {
         return new PartResponse(
                 part.getPartContent(),
-                part.getTypeOfTalent()
+                part.getTypeOfTalent(),
+                part.getImageUrl(),
+                partQuestions.stream()
+                        .map(partQuestion -> partQuestion.getPartQuestion1() + ", " + partQuestion.getPartQuestion2() + ", " + partQuestion.getPartQuestion3())
+                        .collect(Collectors.toList()),
+                curriculums.stream()
+                        .map(Curriculum::getContent)
+                        .collect(Collectors.toList()),
+                Arrays.asList(
+                        commonQuestion.getCommonQuestion1(),
+                        commonQuestion.getCommonQuestion2(),
+                        commonQuestion.getCommonQuestion3(),
+                        commonQuestion.getCommonQuestion4(),
+                        commonQuestion.getCommonQuestion5()
+                )
         );
     }
 }

--- a/src/main/java/com/startlion/startlionserver/repository/CurriculumJpaRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/CurriculumJpaRepository.java
@@ -1,0 +1,11 @@
+package com.startlion.startlionserver.repository;
+
+import com.startlion.startlionserver.domain.entity.Curriculum;
+import com.startlion.startlionserver.domain.entity.Part;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CurriculumJpaRepository extends JpaRepository<Curriculum, Long> {
+    List<Curriculum> findByPartId(Part part);
+}

--- a/src/main/java/com/startlion/startlionserver/repository/PartQuestionJpaRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/PartQuestionJpaRepository.java
@@ -1,0 +1,11 @@
+package com.startlion.startlionserver.repository;
+
+import com.startlion.startlionserver.domain.entity.Part;
+import com.startlion.startlionserver.domain.entity.PartQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PartQuestionJpaRepository extends JpaRepository<PartQuestion, Long> {
+    List<PartQuestion> findByPart(Part part);
+}

--- a/src/main/java/com/startlion/startlionserver/service/PartService.java
+++ b/src/main/java/com/startlion/startlionserver/service/PartService.java
@@ -1,12 +1,21 @@
 package com.startlion.startlionserver.service;
 
 
+import com.startlion.startlionserver.domain.entity.CommonQuestion;
+import com.startlion.startlionserver.domain.entity.Curriculum;
 import com.startlion.startlionserver.domain.entity.Part;
+import com.startlion.startlionserver.domain.entity.PartQuestion;
 import com.startlion.startlionserver.dto.response.part.PartResponse;
+import com.startlion.startlionserver.repository.CommonQuestionJpaRepository;
+import com.startlion.startlionserver.repository.CurriculumJpaRepository;
 import com.startlion.startlionserver.repository.PartJpaRepository;
+import com.startlion.startlionserver.repository.PartQuestionJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +23,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class PartService {
 
     private final PartJpaRepository partJpaRepository;
+    private final PartQuestionJpaRepository partQuestionJpaRepository;
+    private final CurriculumJpaRepository curriculumJpaRepository;
+    private final CommonQuestionJpaRepository commonQuestionJpaRepository;
 
     public PartResponse getPartByName(String name) {
         Part part = partJpaRepository.findByName(name)
                 .orElseThrow( () -> new IllegalArgumentException("해당하는 파트가 없습니다."));
-        return PartResponse.of(part);
+        List<PartQuestion> partQuestions = partQuestionJpaRepository.findByPart(part);
+        List<Curriculum> curriculums = curriculumJpaRepository.findByPartId(part);
+
+        if (partQuestions.isEmpty() && curriculums.isEmpty()) {
+            throw new NoSuchElementException("PartQuestion과 Curriculum이 모두 비어 있습니다.");
+        }
+
+        // 임시로 이렇게 구현했습니다. 후에 파트에 generation을 추가하거나 해야할 듯 합니다.
+        Long generation = partQuestions.isEmpty() ? curriculums.get(0).getGeneration() : partQuestions.get(0).getGeneration();
+        CommonQuestion commonQuestion = commonQuestionJpaRepository.findByGeneration(generation)
+                .orElseThrow(() -> new NoSuchElementException("해당 세대의 CommonQuestion이 없습니다."));
+
+        return PartResponse.of(part, partQuestions, curriculums, commonQuestion);
     }
 }


### PR DESCRIPTION
## 티켓

[SL-11]

## 변경사항
- parts 호출 시 partContent, typeOfTalent, imageUrl, partQuestions, curriculumContents, commonQuestions도 리턴되도록 수정했습니다.

<br>

## 부가설명
- gpt 돌려서 빠르게 만든 기능이라서 후에 수정이 필요할 것 같습니다.

<br>

## 고려사항


<br>

## 스크린샷
{
    "partContent": "백엔드 콘텐츠",
    "typeOfTalent": "백엔드 능력",
    "imageUrl": null,
    "partQuestions": [
        "백엔드 질문1, 백엔드 질문2, 백엔드 질문3"
    ],
    "curriculumContents": [
        "백엔드 커리큘럼"
    ],
    "commonQuestions": [
        "공통 질문1",
        "공통 질문2",
        "공통 질문3",
        "공통 질문4",
        "공통 질문5"
    ]
}
- 이런 식으로 리턴됩니다.
