### PR TITLE
[SL-15 CHORE] application 수정

### DIFF
--- a/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
+++ b/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers(PathRequest.toH2Console()).permitAll()
+//                .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .requestMatchers(createMvcRequestMatcherForWhitelist(mvc)).permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
+++ b/src/main/java/com/startlion/startlionserver/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITE_LIST = {
+            "",
             "/",
             "/health",
             "/login/oauth2/code/google",

--- a/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
@@ -42,10 +42,19 @@ public class ApplicationController {
 
     // 지원서 저장하기의 경우 받아야 하는 Body 정보가 다르기 때문에, 4개의 API로 나누었습니다.
     // 지원서 저장하기 1페이지
-    @Operation(summary = "지원서 저장하기 1페이지")
+
+    @Operation(summary = "지원서 저장하기 1페이지 -> GET application/으로 접근했을 때 사용")
+    @PostMapping
+    public ResponseEntity<String> postApplicationPage1(@RequestBody ApplicationPage1PutRequest request, @RequestParam Long generation, Principal principal){
+        Long applicationId = applicationService.createApplicationPage1(request, generation, UserUtil.getUserId(principal));
+        URI uri = URI.create("/application/" + applicationId);
+        return ResponseEntity.created(uri).body("Application ID: " + applicationId);
+    }
+
+    @Operation(summary = "지원서 저장하기 1페이지 -> GET application/{applicationId}으로 접근했을 때 사용")
     @PutMapping("/{applicationId}/page1")
-    public ResponseEntity<String> updateApplicationPage1(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage1PutRequest request, @RequestParam Long generationId, Principal principal){
-        URI uri = URI.create("/application/" + applicationService.updateApplicationPage1(applicationId, request, generationId, UserUtil.getUserId(principal)));
+    public ResponseEntity<String> updateApplicationPage1(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage1PutRequest request, @RequestParam Long generation, Principal principal){
+        URI uri = URI.create("/application/" + applicationService.updateApplicationPage1(applicationId, request, generation, UserUtil.getUserId(principal)));
         return ResponseEntity.created(uri).body("지원서 1페이지 저장 완료");
     }
 

--- a/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/ApplicationController.java
@@ -52,24 +52,24 @@ public class ApplicationController {
     // 지원서 저장하기 2페이지
     @Operation(summary = "지원서 저장하기 2페이지")
     @PutMapping("/{applicationId}/page2")
-    public ResponseEntity<String> updateApplicationPage2(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage2PutRequest request){
-        URI uri = URI.create("/application/" + applicationService.updateApplicationPage2(applicationId, request));
+    public ResponseEntity<String> updateApplicationPage2(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage2PutRequest request, Principal principal){
+        URI uri = URI.create("/application/" + applicationService.updateApplicationPage2(applicationId, request, UserUtil.getUserId(principal)));
         return ResponseEntity.created(uri).body("지원서 2페이지 저장 완료");
     }
 
     // 지원서 저장하기 3페이지
     @Operation(summary = "지원서 저장하기 3페이지")
     @PutMapping("/{applicationId}/page3")
-    public ResponseEntity<String> updateApplicationPage3(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage3PutRequest request){
-        URI uri = URI.create("/application/" + applicationService.updateApplicationPage3(applicationId, request));
+    public ResponseEntity<String> updateApplicationPage3(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage3PutRequest request, Principal principal){
+        URI uri = URI.create("/application/" + applicationService.updateApplicationPage3(applicationId, request, UserUtil.getUserId(principal)));
         return ResponseEntity.created(uri).body("지원서 3페이지 저장 완료");
     }
 
     // 지원서 저장하기 4페이지 -> 제출
     @Operation(summary = "지원서 저장하기 4페이지 -> 제출")
     @PutMapping("/{applicationId}/page4")
-    public ResponseEntity<String> updateApplicationPage4(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage4PutRequest request){
-        URI uri = URI.create("/application/" + applicationService.updateApplicationPage4(applicationId, request));
+    public ResponseEntity<String> updateApplicationPage4(@PathVariable @Parameter(description = "지원서 ID") Long applicationId, @RequestBody ApplicationPage4PutRequest request, Principal principal){
+        URI uri = URI.create("/application/" + applicationService.updateApplicationPage4(applicationId, request, UserUtil.getUserId(principal)));
         return ResponseEntity.created(uri).body("지원서 제출 완료");
     }
 

--- a/src/main/java/com/startlion/startlionserver/controller/HomeController.java
+++ b/src/main/java/com/startlion/startlionserver/controller/HomeController.java
@@ -1,0 +1,12 @@
+package com.startlion.startlionserver.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+public class HomeController {
+    @GetMapping
+    public void home(){}
+}

--- a/src/main/java/com/startlion/startlionserver/domain/entity/Application.java
+++ b/src/main/java/com/startlion/startlionserver/domain/entity/Application.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -83,15 +84,15 @@ public class Application extends BaseTimeEntity {
     @ColumnDefault("''")
     private String portfolio;
 
-    @ColumnDefault("''")
-    private String interview;
+    @OneToMany(mappedBy = "application", cascade = CascadeType.ALL)
+    private List<InterviewTime> interviewTimes = new ArrayList<>();
 
     @ColumnDefault("'N'")
     private String status;
 
     //builder
     @Builder
-    public Application(Answer answer, User user, CommonQuestion generation, boolean isAgreed, String name, String gender, Integer studentNum, String major, String multiMajor, String semester, String phone, String email, List<PathToKnow> pathToKnows, Part part, String portfolio, String interview, String status){
+    public Application(Answer answer, User user, CommonQuestion generation, boolean isAgreed, String name, String gender, Integer studentNum, String major, String multiMajor, String semester, String phone, String email, List<PathToKnow> pathToKnows, Part part, String portfolio, List<InterviewTime> interviewTimes, String status){
         this.answer = answer;
         this.user = user;
         this.generation = generation;
@@ -107,7 +108,7 @@ public class Application extends BaseTimeEntity {
         this.pathToKnows = pathToKnows;
         this.part = part;
         this.portfolio = portfolio;
-        this.interview = interview;
+        this.interviewTimes = interviewTimes;
         this.status = status;
     }
 
@@ -136,8 +137,9 @@ public class Application extends BaseTimeEntity {
         this.answer = answer;
     }
 
-    public void updateInterview(String interview, String status) {
-        this.interview = interview;
+    public void updateInterview(List<InterviewTime> interviewTimes, String status) {
+        this.interviewTimes.clear();
+        this.interviewTimes.addAll(interviewTimes);
         this.status = status; // interview가 있다면 제출한 것이므로 status = 'Y'
     }
 
@@ -147,6 +149,12 @@ public class Application extends BaseTimeEntity {
 
     public void updateCommonQuestion(CommonQuestion generation) {
         this.generation = generation;
+    }
+
+    public List<List<Integer>> getInterviewTimes() {
+        return this.interviewTimes.stream()
+                .map(InterviewTime::getTime)
+                .collect(Collectors.toList());
     }
 }
 

--- a/src/main/java/com/startlion/startlionserver/domain/entity/InterviewTime.java
+++ b/src/main/java/com/startlion/startlionserver/domain/entity/InterviewTime.java
@@ -1,0 +1,31 @@
+package com.startlion.startlionserver.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table
+public class InterviewTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection
+    @CollectionTable(name = "interview_time_time", joinColumns = @JoinColumn(name = "interview_time_id"))
+    @Column(name = "time")
+    private List<Integer> time;
+
+    @ManyToOne
+    @JoinColumn(name = "application_id")
+    private Application application;
+
+    public InterviewTime(List<Integer> time, Application application) {
+        this.time = time;
+        this.application = application;
+    }
+}

--- a/src/main/java/com/startlion/startlionserver/domain/entity/User.java
+++ b/src/main/java/com/startlion/startlionserver/domain/entity/User.java
@@ -54,7 +54,7 @@ public class User extends BaseTimeEntity {
         this.refreshToken = refreshToken;
     }
 
-    public void updateImageUrl(String imageUrl){
-        this.imageUrl = imageUrl;
-    }
+//    public void updateImageUrl(String imageUrl){
+//        this.imageUrl = imageUrl;
+//    }
 }

--- a/src/main/java/com/startlion/startlionserver/dto/request/application/ApplicationPage4PutRequest.java
+++ b/src/main/java/com/startlion/startlionserver/dto/request/application/ApplicationPage4PutRequest.java
@@ -3,8 +3,10 @@ package com.startlion.startlionserver.dto.request.application;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class ApplicationPage4PutRequest {
     @Schema(description = "면접 시간", example = "true", required = true)
-    private String interview;
+    private List<List<Integer>> interview;
 }

--- a/src/main/java/com/startlion/startlionserver/dto/response/application/ApplicationGetResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/application/ApplicationGetResponse.java
@@ -39,11 +39,11 @@ public class ApplicationGetResponse {
 
     private String portfolio;
 
-    private String interview;
+    private List<List<Integer>> interview;
 
     private String status;
 
     public static ApplicationGetResponse of(Application application){
-        return new ApplicationGetResponse(application.getAnswer(), application.getGeneration(), application.getIsAgreed(), application.getName(), application.getGender(), application.getStudentNum(), application.getMajor(), application.getMultiMajor(), application.getSemester(), application.getPhone(), application.getEmail(), application.getPathToKnows(), application.getPart(), application.getPortfolio(), application.getInterview(), application.getStatus());
+        return new ApplicationGetResponse(application.getAnswer(), application.getGeneration(), application.getIsAgreed(), application.getName(), application.getGender(), application.getStudentNum(), application.getMajor(), application.getMultiMajor(), application.getSemester(), application.getPhone(), application.getEmail(), application.getPathToKnows(), application.getPart(), application.getPortfolio(), application.getInterviewTimes(), application.getStatus());
     }
 }

--- a/src/main/java/com/startlion/startlionserver/dto/response/application/ApplicationPage4GetResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/application/ApplicationPage4GetResponse.java
@@ -4,11 +4,13 @@ package com.startlion.startlionserver.dto.response.application;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 public class ApplicationPage4GetResponse {
-    private String interview;
-    public static ApplicationPage4GetResponse of(String interview) {
+    private List<List<Integer>> interview;
+    public static ApplicationPage4GetResponse of(List<List<Integer>> interview) {
         return new ApplicationPage4GetResponse(interview);
     }
 }

--- a/src/main/java/com/startlion/startlionserver/repository/InterviewTimeRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/InterviewTimeRepository.java
@@ -1,0 +1,9 @@
+package com.startlion.startlionserver.repository;
+
+import com.startlion.startlionserver.domain.entity.Application;
+import com.startlion.startlionserver.domain.entity.InterviewTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewTimeRepository extends JpaRepository<InterviewTime, Long> {
+    void deleteAllByApplication(Application application);
+}

--- a/src/main/java/com/startlion/startlionserver/service/ApplicationService.java
+++ b/src/main/java/com/startlion/startlionserver/service/ApplicationService.java
@@ -38,6 +38,9 @@ public class ApplicationService {
     public ResponseEntity<?> getById(Long applicationId, int page, Long userId) {
         Application application = applicationJpaRepository.findById(applicationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 applicationId를 가진 지원서가 존재하지 않습니다."));
+
+        checkApplicationOwner(application, userId);
+
         switch (page) {
             case 1:
                 return ResponseEntity.ok(ApplicationPage1GetResponse.of(application));
@@ -51,6 +54,13 @@ public class ApplicationService {
                 return ResponseEntity.ok(ApplicationPage4GetResponse.of(application.getInterview()));
             default:
                 throw new IllegalArgumentException("페이지 번호가 잘못되었습니다.");
+        }
+    }
+
+    // 본인의 지원서인지 체크
+    private void checkApplicationOwner(Application application, Long userId){
+        if(userId != application.getUser().getUserId()){
+            throw new IllegalArgumentException("본인의 application이 아닙니다.");
         }
     }
 
@@ -87,7 +97,7 @@ public class ApplicationService {
                 pathToKnowJpaRepository.save(pathToKnow);
             }
 
-            application.updateApplication(request.getIsAgreed(), user,request.getName(), request.getGender(), request.getStudentNum(), request.getMajor(), request.getMultiMajor(), request.getSemester(), request.getPhone(), request.getEmail(), request.getPathToKnows(), request.getPart(), "S", commonQuestion);
+            application.updateApplication(request.getIsAgreed(), user, request.getName(), request.getGender(), request.getStudentNum(), request.getMajor(), request.getMultiMajor(), request.getSemester(), request.getPhone(), request.getEmail(), request.getPathToKnows(), request.getPart(), "S", commonQuestion);
 
             applicationJpaRepository.save(application); //Application 저장
         } else {
@@ -153,7 +163,7 @@ public class ApplicationService {
         Application application = applicationJpaRepository.findById(applicationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 applicationId를 가진 지원서가 존재하지 않습니다."));
 
-        // answer가 있으면 update 있으면 create
+        // answer가 있으면 update 없으면 create
         if (application.getAnswer() == null) {
             Answer newAnswer = answerService.createAnswer(application, request);
             application.setAnswer(newAnswer);

--- a/src/main/java/com/startlion/startlionserver/service/ApplicationService.java
+++ b/src/main/java/com/startlion/startlionserver/service/ApplicationService.java
@@ -87,6 +87,8 @@ public class ApplicationService {
         if (optionalApplication.isPresent()) {
             application = optionalApplication.get();
 
+            checkApplicationOwner(application, userId); // 본인 application인지 확인
+
             deletePathToKnows(application); // 기존의 path to know 삭제
 
             // path to know 저장
@@ -159,9 +161,11 @@ public class ApplicationService {
 
     // 지원서 2페이지 저장
     @Transactional
-    public Long updateApplicationPage2(Long applicationId, ApplicationPage2PutRequest request) {
+    public Long updateApplicationPage2(Long applicationId, ApplicationPage2PutRequest request, Long userId) {
         Application application = applicationJpaRepository.findById(applicationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 applicationId를 가진 지원서가 존재하지 않습니다."));
+
+        checkApplicationOwner(application, userId);
 
         // answer가 있으면 update 없으면 create
         if (application.getAnswer() == null) {
@@ -177,9 +181,11 @@ public class ApplicationService {
 
     // 지원서 3페이지 저장
     @Transactional
-    public Long updateApplicationPage3(Long applicationId, ApplicationPage3PutRequest request) {
+    public Long updateApplicationPage3(Long applicationId, ApplicationPage3PutRequest request, Long userId) {
         Application application = applicationJpaRepository.findById(applicationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 applicationId를 가진 지원서가 존재하지 않습니다."));
+
+        checkApplicationOwner(application, userId);
 
         // answer가 있으면 update 있으면 create
         if (application.getAnswer() == null) {
@@ -197,9 +203,11 @@ public class ApplicationService {
 
     // 지원서 4페이지 저장(제출)
     @Transactional
-    public Long updateApplicationPage4(Long applicationId, ApplicationPage4PutRequest request) {
+    public Long updateApplicationPage4(Long applicationId, ApplicationPage4PutRequest request, Long userId) {
         Application application = applicationJpaRepository.findById(applicationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 applicationId를 가진 지원서가 존재하지 않습니다."));
+
+        checkApplicationOwner(application, userId);
 
         application.updateInterview(request.getInterview(), "Y");
 


### PR DESCRIPTION
## 티켓

[SL-15]
<br>

## 변경사항
- 배포 환경에서 h2 관련 에러가 나서 주석처리
- 메인 페이지 controller 추가 및 인가 제외
- 본인의 application만 접근 가능하도록 에러 처리
- page1 PUT을 PUT과 POST로 분리
- 코드 메서드 분리


## 부가설명
- 본인의 application 외의 applicationId로 접근할 시 에러를 띄우도록 수정했습니다.
- 기존의 방식은 PUT을 활용해서 해당 applicationId가 없는 경우 application의 컬럼을 만드는 방식이었습니다. 하지만 이 방식을 사용하면 지원서를 생성할 때 applicationId를 결정해줘야 한다는 문제가 있습니다. 그래서 GET application/ 으로 접근할 때는 POST를 사용해서 application 컬럼을 만든 후 id를 반환하도록 했고, GET application/{applicationId}로 접근한 경우에는 id값이 있으므로 PUT을 사용해서 업데이트 하도록 수정했습니다.


<br>

## 고려사항
- 더 좋은 방법이 있거나 수정사항 있으면 알려주세요!

<br>

## 스크린샷
