### PR TITLE
[SL-11 FIX] partquestion 독립 문자열로 변경

### DIFF
--- a/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public record PartResponse(
@@ -36,7 +37,7 @@ public record PartResponse(
                 part.getTypeOfTalent(),
                 part.getImageUrl(),
                 partQuestions.stream()
-                        .map(partQuestion -> partQuestion.getPartQuestion1() + ", " + partQuestion.getPartQuestion2() + ", " + partQuestion.getPartQuestion3())
+                        .flatMap(partQuestion -> Stream.of(partQuestion.getPartQuestion1(), partQuestion.getPartQuestion2(), partQuestion.getPartQuestion3()))
                         .collect(Collectors.toList()),
                 curriculums.stream()
                         .map(Curriculum::getContent)

--- a/src/main/resources/application-secret.properties
+++ b/src/main/resources/application-secret.properties
@@ -1,0 +1,14 @@
+DEV_DB_ENDPOINT=startlion-server-db.cgm2fyztj43d.ap-northeast-2.rds.amazonaws.com
+DEV_DB_USERNAME=startlionadmin
+DEV_DB_PASSWORD=wndgkgk123!
+DATABASE_NAME=startliondb
+GOOGLE_REDIRECT_URL=http://localhost:8080/login/oauth2/code/google
+GOOGLE_CLIENT_ID=1020698091434-ogc03mvgc4f2fq4q3f7vktln3u0hgvdv.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=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
+GOOGLE_AUTH_URL=https://oauth2.googleapis.com
+GOOGLE_LOGIN_URL=https://accounts.google.com
+AWS_ACCESS_KEY=AKIA5KNAVWGTMGK65TNJ
+AWS_SECRET_KEY=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
+AWS_REGION=ap-northeast-2
+AWS_BUCKET=startlion
+JWT_SECRET=likelionwndgkgkwndgkgk!


### PR DESCRIPTION
## 티켓

<br>

## 변경사항


기존의

"partQuestions": [
    "기획질문1, 기획질문2, 기획질문3"
  ],

이 형식에서

  "partQuestions": [
    "기획질문1",
 "기획질문2",
 "기획질문3",
  ],

독립 문자열로 출력되도록 변경했습니다.

<br>

## 부가설명


<br>

## 고려사항


<br>

## 스크린샷
