### PR TITLE
[SL-11 FIX] partquestion, curriculum 출력 형태 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ out/
 src/main/resources/application.yml
 application.yml
 src/main/resources/application-SECRET-KEY.properties
+src/main/resources/application-secret.properties
 
 .DS_Store
 application-oauth.properties

--- a/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 
 
 public record PartResponse(
+        String partName,
         String partContent,
         String typeOfTalent,
 
@@ -33,6 +34,7 @@ public record PartResponse(
 
     public static PartResponse of(Part part, List<PartQuestion> partQuestions, Curriculum curriculum, CommonQuestion commonQuestion) {
         return new PartResponse(
+                part.getName(),
                 part.getPartContent(),
                 part.getTypeOfTalent(),
                 part.getImageUrl(),

--- a/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
@@ -19,7 +19,7 @@ public record PartResponse(
         String imageUrl,
 
         List<String> partQuestions,
-        List<String> curriculumContents,
+        String curriculumContents,
         List<String> commonQuestions,
         Long curriculumGeneration
 ) {
@@ -31,7 +31,7 @@ public record PartResponse(
 //                part.getImageUrl()
 //        );
 
-    public static PartResponse of(Part part, List<PartQuestion> partQuestions, List<Curriculum> curriculums, CommonQuestion commonQuestion) {
+    public static PartResponse of(Part part, List<PartQuestion> partQuestions, Curriculum curriculum, CommonQuestion commonQuestion) {
         return new PartResponse(
                 part.getPartContent(),
                 part.getTypeOfTalent(),
@@ -39,9 +39,7 @@ public record PartResponse(
                 partQuestions.stream()
                         .flatMap(partQuestion -> Stream.of(partQuestion.getPartQuestion1(), partQuestion.getPartQuestion2(), partQuestion.getPartQuestion3()))
                         .collect(Collectors.toList()),
-                curriculums.stream()
-                        .map(Curriculum::getContent)
-                        .collect(Collectors.toList()),
+                curriculum.getContent(),
                 Arrays.asList(
                         commonQuestion.getCommonQuestion1(),
                         commonQuestion.getCommonQuestion2(),

--- a/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
+++ b/src/main/java/com/startlion/startlionserver/dto/response/part/PartResponse.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public record PartResponse(
@@ -36,7 +37,7 @@ public record PartResponse(
                 part.getTypeOfTalent(),
                 part.getImageUrl(),
                 partQuestions.stream()
-                        .map(partQuestion -> partQuestion.getPartQuestion1() + ", " + partQuestion.getPartQuestion2() + ", " + partQuestion.getPartQuestion3())
+                        .flatMap(partQuestion -> Stream.of(partQuestion.getPartQuestion1(), partQuestion.getPartQuestion2(), partQuestion.getPartQuestion3()))
                         .collect(Collectors.toList()),
                 curriculums.stream()
                         .map(Curriculum::getContent)

--- a/src/main/java/com/startlion/startlionserver/repository/CurriculumJpaRepository.java
+++ b/src/main/java/com/startlion/startlionserver/repository/CurriculumJpaRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CurriculumJpaRepository extends JpaRepository<Curriculum, Long> {
-    List<Curriculum> findByPartId(Part part); // Part를 기반으로 Curriculum을 조회
+    Optional<Curriculum> findByPartId(Part part); // Part를 기반으로 Curriculum을 조회
 }

--- a/src/main/java/com/startlion/startlionserver/service/PartService.java
+++ b/src/main/java/com/startlion/startlionserver/service/PartService.java
@@ -39,7 +39,7 @@ public class PartService {
             throw new NoSuchElementException("PartQuestion이 비어 있습니다.");
         }
         // 임시로 이렇게 구현했습니다. 후에 파트에 generation을 추가하거나 해야할 듯 합니다.
-        Long generation = partQuestions.isEmpty() ? curriculums.get(0).getGeneration() : partQuestions.get(0).getGeneration();
+        Long generation = partQuestions.isEmpty() ? curriculum.getGeneration() : partQuestions.get(0).getGeneration();
         CommonQuestion commonQuestion = commonQuestionJpaRepository.findByGeneration(generation)
                 .orElseThrow(() -> new NoSuchElementException("해당 세대의 CommonQuestion이 없습니다."));
 

--- a/src/main/java/com/startlion/startlionserver/service/PartService.java
+++ b/src/main/java/com/startlion/startlionserver/service/PartService.java
@@ -30,17 +30,19 @@ public class PartService {
     public PartResponse getPartByName(String name) {
         Part part = partJpaRepository.findByName(name)
                 .orElseThrow( () -> new IllegalArgumentException("해당하는 파트가 없습니다."));
+        Curriculum curriculum = curriculumJpaRepository.findByPartId(part)
+                .orElseThrow(() -> new NoSuchElementException("해당 파트의 커리큘럼이 없습니다."));
         List<PartQuestion> partQuestions = partQuestionJpaRepository.findByPart(part);
-        List<Curriculum> curriculums = curriculumJpaRepository.findByPartId(part);
+        //List<Curriculum> curriculums = curriculumJpaRepository.findByPartId(part);
 
-        if (partQuestions.isEmpty() && curriculums.isEmpty()) {
-            throw new NoSuchElementException("PartQuestion과 Curriculum이 모두 비어 있습니다.");
+        if (partQuestions.isEmpty()) {
+            throw new NoSuchElementException("PartQuestion이 비어 있습니다.");
         }
 
         Long generation = part.getGeneration();
         CommonQuestion commonQuestion = commonQuestionJpaRepository.findByGeneration(generation)
                 .orElseThrow(() -> new NoSuchElementException("해당 기수의 CommonQuestion이 없습니다."));
 
-        return PartResponse.of(part, partQuestions, curriculums, commonQuestion);
+        return PartResponse.of(part, partQuestions, curriculum, commonQuestion);
     }
 }


### PR DESCRIPTION
## 티켓

SL-11
<br>

## 변경사항


기존의

"partQuestions": [
"기획질문1, 기획질문2, 기획질문3"
],

이 형식에서

"partQuestions": [
"기획질문1",
"기획질문2",
"기획질문3",
],

독립 문자열로 출력되도록 변경했습니다.

커리큘럼은 문자열 배열이 아닌 문자열 출력 형태로 변경했습니다.

<br>

## 부가설명
커리큘럼은 content 데이터에

1. 파이썬 문법\n2. 장고 시작하기\n3. 스프링 어쩌구저쩌구\n4. 인증인가 어쩌구 저쩌구\n5. 다섯번째\n6. 여섯번째\n7. 일곱번째\n
이렇게 들어갈 예정입니다.
<br>

## 고려사항


<br>

## 스크린샷
